### PR TITLE
Refactor payment address handling in tipping service for Solana network

### DIFF
--- a/src/server/tip-server.ts
+++ b/src/server/tip-server.ts
@@ -338,9 +338,10 @@ const processTipWithX402 = async (req: any, res: any, config: TipConfig): Promis
 // x402 Payment endpoint for tipping service with dynamic pricing
 const setupTipRoute = (app: any) => {
   app.post('/tip-solana', async (req: any, res: any): Promise<void> => {
+    const payTo = process.env.CDP_AGENT_ADDRESS_SOLANA as SolanaAddress;
     await processTipWithX402(req, res, {
       network: 'solana',
-      paymentAddress: process.env.CDP_AGENT_ADDRESS_SOLANA as SolanaAddress,
+      paymentAddress: payTo,
       executeTransfers: false
     });
   });


### PR DESCRIPTION
- Introduced a variable `payTo` to store the Solana payment address from environment variables for improved readability.
- Updated the `setupTipRoute` function to use the new variable instead of directly accessing the environment variable, enhancing code clarity.